### PR TITLE
Add Dafny printer (issue #3)

### DIFF
--- a/tests/test_printer.py
+++ b/tests/test_printer.py
@@ -1,0 +1,123 @@
+import re
+
+from xdsl.dialects.builtin import IntegerType, ModuleOp
+from xdsl.ir import Block, Region
+
+from veripy.printer import print_dafny, rewrite_ensures
+from veripy.py import BinOp, ConstantOp, FuncOp, IfOp, NegOp, ParamRefOp, ReturnOp
+
+i64 = IntegerType(64)
+i1 = IntegerType(1)
+
+
+def _normalize(s: str) -> str:
+    return re.sub(r"\s+", " ", s).strip()
+
+
+# --- ensures rewriting ---
+
+
+def test_rewrite_ensures_replaces_result_with_r():
+    assert rewrite_ensures("result >= 0") == "r >= 0"
+
+
+def test_rewrite_ensures_replaces_or_with_logical_or():
+    assert rewrite_ensures("result == x or result == -x") == "r == x || r == -x"
+
+
+def test_rewrite_ensures_leaves_unrelated_string_unchanged():
+    assert rewrite_ensures("x > 0") == "x > 0"
+
+
+def test_rewrite_ensures_preserves_result_prefix_in_identifier():
+    assert rewrite_ensures("result_code >= 0") == "result_code >= 0"
+
+
+# --- per-op emission ---
+
+
+def test_constant_emits_literal():
+    c = ConstantOp(0, i64)
+    func = FuncOp("f", ["x"], ([i64], [i64]), body=Region([Block([c, ReturnOp(c)])]))
+    out = print_dafny(ModuleOp([func]))
+    assert "r := 0;" in out
+
+
+def test_param_ref_emits_name():
+    p = ParamRefOp("x", i64)
+    func = FuncOp("f", ["x"], ([i64], [i64]), body=Region([Block([p, ReturnOp(p)])]))
+    out = print_dafny(ModuleOp([func]))
+    assert "r := x;" in out
+
+
+def test_binop_ge_emits_infix():
+    x = ParamRefOp("x", i64)
+    zero = ConstantOp(0, i64)
+    cmp = BinOp("ge", x, zero, i1)
+    then_block = Block([ReturnOp(x)])
+    if_op = IfOp(cmp, Region([then_block]))
+    func = FuncOp("f", ["x"], ([i64], [i64]), body=Region([Block([x, zero, cmp, if_op])]))
+    out = print_dafny(ModuleOp([func]))
+    assert "if x >= 0 {" in out
+
+
+def test_neg_emits_minus_prefix():
+    x = ParamRefOp("x", i64)
+    neg = NegOp(x, i64)
+    func = FuncOp("f", ["x"], ([i64], [i64]), body=Region([Block([x, neg, ReturnOp(neg)])]))
+    out = print_dafny(ModuleOp([func]))
+    assert "r := -x;" in out
+
+
+def test_return_emits_assign_then_return():
+    c = ConstantOp(42, i64)
+    func = FuncOp("f", [], ([], [i64]), body=Region([Block([c, ReturnOp(c)])]))
+    out = print_dafny(ModuleOp([func]))
+    assert "r := 42;" in out
+    assert "return;" in out
+
+
+def test_if_with_else_emits_both_branches():
+    x = ParamRefOp("x", i64)
+    zero = ConstantOp(0, i64)
+    cmp = BinOp("ge", x, zero, i1)
+    then_block = Block([ReturnOp(x)])
+    neg = NegOp(x, i64)
+    else_block = Block([neg, ReturnOp(neg)])
+    if_op = IfOp(cmp, Region([then_block]), Region([else_block]))
+    func = FuncOp("f", ["x"], ([i64], [i64]), body=Region([Block([x, zero, cmp, if_op])]))
+    out = print_dafny(ModuleOp([func]))
+    assert "if x >= 0 {" in out
+    assert "r := x;" in out
+    assert "r := -x;" in out
+
+
+# --- full function ---
+
+
+def test_abs_full_output_matches_expected_dafny():
+    x_ref = ParamRefOp("x", i64)
+    zero = ConstantOp(0, i64)
+    cond = BinOp("ge", x_ref, zero, i1)
+    then_block = Block([ReturnOp(x_ref)])
+    neg_x = NegOp(x_ref, i64)
+    else_block = Block([neg_x, ReturnOp(neg_x)])
+    if_op = IfOp(cond, Region([then_block]), Region([else_block]))
+    body = Region([Block([x_ref, zero, cond, if_op])])
+    func = FuncOp("abs", ["x"], ([i64], [i64]), ensures=["result >= 0", "result == x or result == -x"], body=body)
+    module = ModuleOp([func])
+
+    expected = """\
+method abs(x: int) returns (r: int)
+  ensures r >= 0
+  ensures r == x || r == -x
+{
+  if x >= 0 {
+    r := x;
+    return;
+  }
+  r := -x;
+  return;
+}"""
+
+    assert _normalize(print_dafny(module)) == _normalize(expected)

--- a/veripy/printer.py
+++ b/veripy/printer.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+
+from xdsl.dialects.builtin import IntegerType, ModuleOp
+from xdsl.ir import Operation, SSAValue
+
+from veripy.py import BinOp, ConstantOp, FuncOp, IfOp, NegOp, ParamRefOp, ReturnOp
+
+OP_SYMBOLS = {"ge": ">=", "le": "<=", "gt": ">", "lt": "<", "eq": "==", "ne": "!=", "add": "+", "sub": "-", "mul": "*"}
+
+
+def rewrite_ensures(clause: str) -> str:
+    s = re.sub(r"\bresult\b", "r", clause)
+    return re.sub(r"\bor\b", "||", s)
+
+
+def print_dafny(module: ModuleOp) -> str:
+    parts = []
+    for op in module.body.block.ops:
+        if isinstance(op, FuncOp):
+            parts.append(_print_func(op))
+    return "\n".join(parts)
+
+
+def _type_str(ty: IntegerType) -> str:
+    if ty.width.data == 1:
+        return "bool"
+    return "int"
+
+
+def _print_func(func: FuncOp) -> str:
+    param_names = [attr.data for attr in func.param_names]
+    param_types = list(func.function_type.inputs)
+    params = [f"{name}: {_type_str(ty)}" for name, ty in zip(param_names, param_types)]
+    ret_type = list(func.function_type.outputs)[0]
+
+    lines = [f"method {func.sym_name.data}({', '.join(params)}) returns (r: {_type_str(ret_type)})"]
+
+    for clause in func.requires:
+        lines.append(f"  requires {rewrite_ensures(clause.data)}")
+    for clause in func.ensures:
+        lines.append(f"  ensures {rewrite_ensures(clause.data)}")
+
+    lines.append("{")
+    exprs: dict[SSAValue, str] = {}
+    lines.extend(_emit_ops(func.body.block.ops, exprs, "  "))
+    lines.append("}")
+
+    return "\n".join(lines)
+
+
+def _emit_ops(ops: Iterable[Operation], exprs: dict[SSAValue, str], indent: str) -> list[str]:
+    lines: list[str] = []
+    for op in ops:
+        if isinstance(op, ConstantOp):
+            exprs[op.result] = str(op.value.value.data)
+        elif isinstance(op, ParamRefOp):
+            exprs[op.result] = op.param_name.data
+        elif isinstance(op, BinOp):
+            exprs[op.result] = f"{exprs[op.lhs]} {OP_SYMBOLS[op.op_kind.data]} {exprs[op.rhs]}"
+        elif isinstance(op, NegOp):
+            exprs[op.result] = f"-{exprs[op.operand]}"
+        elif isinstance(op, ReturnOp):
+            lines.append(f"{indent}r := {exprs[op.value]};")
+            lines.append(f"{indent}return;")
+        elif isinstance(op, IfOp):
+            lines.append(f"{indent}if {exprs[op.cond]} {{")
+            lines.extend(_emit_ops(op.then_region.block.ops, exprs, indent + "  "))
+            lines.append(f"{indent}}}")
+            if len(op.else_region.blocks) > 0:
+                lines.extend(_emit_ops(op.else_region.block.ops, exprs, indent))
+    return lines


### PR DESCRIPTION
## Summary
- Implements `veripy/printer.py` with `print_dafny(module)` that walks py dialect IR and emits syntactically valid Dafny source code
- Handles `result` → `r` and `or` → `||` rewriting in ensures/requires clauses (word-boundary safe)
- Covers all MVP ops: ConstantOp, ParamRefOp, BinOp, NegOp, ReturnOp, IfOp, FuncOp
- 11 tests in `tests/test_printer.py` covering ensures rewriting, per-op emission, and full `abs` function end-to-end

## Test plan
- [x] `test_rewrite_ensures_*` — 4 tests for clause rewriting (result→r, or→||, unchanged strings, word-boundary safety)
- [x] `test_constant_emits_literal` — ConstantOp(0) → `r := 0;`
- [x] `test_param_ref_emits_name` — ParamRefOp("x") → `r := x;`
- [x] `test_binop_ge_emits_infix` — BinOp("ge", x, 0) → `if x >= 0 {`
- [x] `test_neg_emits_minus_prefix` — NegOp(x) → `r := -x;`
- [x] `test_return_emits_assign_then_return` — ReturnOp → `r := 42;` + `return;`
- [x] `test_if_with_else_emits_both_branches` — IfOp with then/else regions
- [x] `test_abs_full_output_matches_expected_dafny` — full abs IR → expected Dafny output (whitespace-normalized)

Closes #3