### PR TITLE
Wire up CLI: read .py, emit .dfy, verify via Docker

### DIFF
--- a/docker/dafny/Dockerfile
+++ b/docker/dafny/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:22.04
+RUN apt-get update && apt-get install -y wget unzip && \
+    wget -q https://github.com/dafny-lang/dafny/releases/download/v4.9.2/dafny-4.9.2-x64-ubuntu-20.04.zip -O /tmp/dafny.zip && \
+    unzip /tmp/dafny.zip -d /opt && \
+    rm /tmp/dafny.zip && \
+    apt-get clean
+ENV PATH="/opt/dafny:$PATH"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import pytest
+
+ABS_SOURCE = """\
+def abs(x: int) -> int:
+    #@ ensures result >= 0
+    #@ ensures result == x or result == -x
+    if x >= 0:
+        return x
+    return -x
+"""
+
+EXPECTED_DFY = """\
+method abs(x: int) returns (r: int)
+  ensures r >= 0
+  ensures r == x || r == -x
+{
+  if x >= 0 {
+    r := x;
+    return;
+  }
+  r := -x;
+  return;
+}
+"""
+
+
+def _docker_image_exists(name: str) -> bool:
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(["docker", "image", "inspect", name], capture_output=True).returncode == 0
+
+
+def test_cli_writes_dfy_file(tmp_path):
+    src = tmp_path / "abs.py"
+    src.write_text(ABS_SOURCE)
+    subprocess.run(["uv", "run", "python", "-m", "veripy", str(src)], check=False)
+    assert (tmp_path / "abs.dfy").exists()
+
+
+def test_cli_dfy_content_matches_expected(tmp_path):
+    src = tmp_path / "abs.py"
+    src.write_text(ABS_SOURCE)
+    subprocess.run(["uv", "run", "python", "-m", "veripy", str(src)], check=False)
+    assert (tmp_path / "abs.dfy").read_text() == EXPECTED_DFY
+
+
+def test_cli_nonexistent_file_exits_1():
+    result = subprocess.run(["uv", "run", "python", "-m", "veripy", "/nonexistent/path.py"], capture_output=True)
+    assert result.returncode == 1
+
+
+@pytest.mark.skipif(not _docker_image_exists("veripy-dafny"), reason="docker or veripy-dafny image not available")
+def test_cli_dafny_verifies_abs(tmp_path):
+    src = tmp_path / "abs.py"
+    src.write_text(ABS_SOURCE)
+    result = subprocess.run(["uv", "run", "python", "-m", "veripy", str(src)])
+    assert result.returncode == 0

--- a/veripy/__main__.py
+++ b/veripy/__main__.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+from veripy.ingestor import ingest
+from veripy.printer import print_dafny
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("file", type=Path)
+    args = parser.parse_args()
+
+    src_path: Path = args.file.resolve()
+    if not src_path.exists():
+        print(f"error: {src_path} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    source = src_path.read_text()
+    module = ingest(source)
+    dfy = print_dafny(module)
+
+    dfy_path = src_path.with_suffix(".dfy")
+    dfy_path.write_text(dfy + "\n")
+
+    result = subprocess.run(
+        ["docker", "run", "--rm", "-v", f"{dfy_path.parent}:/work", "-w", "/work", "veripy-dafny", "dafny", "verify", dfy_path.name],
+    )
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `veripy/__main__.py` — CLI entry point (`python -m veripy foo.py`) that reads a `.py` file, runs ingestor + printer, writes `.dfy` output, and invokes `dafny verify` via ephemeral Docker container (`docker run --rm`)
- Adds `docker/dafny/Dockerfile` — minimal Ubuntu image with Dafny 4.9.2
- Adds `tests/test_cli.py` — 4 tests covering file I/O, content correctness, error handling, and Docker-based verification

## Test plan
- [x] `test_cli_writes_dfy_file` — CLI creates `.dfy` file at expected path
- [x] `test_cli_dfy_content_matches_expected` — `.dfy` content matches expected Dafny output
- [x] `test_cli_nonexistent_file_exits_1` — exits 1 for missing input
- [x] `test_cli_dafny_verifies_abs` — full Docker verification (skipped when image unavailable)

Closes #4