### PR TITLE
Add end-to-end test: abs function verifies via Docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ venv:
 fmt:
 	uvx isort .
 	uvx autoflake --remove-all-unused-imports --recursive --in-place .
-	uvx black --line-length 5000 .
+	uvx black --line-length 5000 --exclude examples .
 	uvx ruff check --fix .
 
 precommit: fmt

--- a/examples/abs.py
+++ b/examples/abs.py
@@ -1,0 +1,6 @@
+def abs(x: int) -> int:
+    #@ ensures result >= 0
+    #@ ensures result == x or result == -x
+    if x >= 0:
+        return x
+    return -x

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+DFY = Path(__file__).resolve().parent.parent / "examples" / "abs.dfy"
+
+
+def _docker_image_exists(name: str) -> bool:
+    if shutil.which("docker") is None:
+        return False
+    return subprocess.run(["docker", "image", "inspect", name], capture_output=True).returncode == 0
+
+
+@pytest.mark.skipif(shutil.which("docker") is None, reason="docker not available")
+@pytest.mark.skipif(not _docker_image_exists("veripy-dafny"), reason="veripy-dafny image not available")
+def test_abs_verifies():
+    try:
+        result = subprocess.run(["uv", "run", "python", "-m", "veripy", "examples/abs.py"])
+        assert result.returncode == 0
+        assert DFY.exists()
+        assert "method abs" in DFY.read_text()
+    finally:
+        DFY.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary
- Adds `examples/abs.py` — the annotated abs function used as the MVP test case
- Adds `tests/test_e2e.py` — black-box integration test that runs the full pipeline (`python -m veripy examples/abs.py`) and asserts Dafny verification passes via Docker
- Excludes `examples/` from black formatting to preserve `#@` annotation syntax

## Test plan
- [x] `test_abs_verifies` — runs CLI end-to-end, asserts exit 0, checks `.dfy` output exists and contains `method abs` (skipped gracefully when Docker unavailable)
- [x] All 44 existing tests still pass

Closes #5