### PR TITLE
Remove unnecessary future annotations import

### DIFF
--- a/veripy/main.py
+++ b/veripy/main.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import ast
 import re
 import subprocess


### PR DESCRIPTION
Project targets Python 3.12+, so `from __future__ import annotations` is redundant — the `X | Y` union syntax has been native since 3.10.