### PR TITLE
Default CLI to resolve + dfy

### DIFF
--- a/tests/filecheck/py_ir.py
+++ b/tests/filecheck/py_ir.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s | filecheck %s
+# RUN: veripy %s -p "" -t mlir | filecheck %s
 
 def f(a: int, b: int) -> int:
     return a + b

--- a/tests/filecheck/verif_ir.py
+++ b/tests/filecheck/verif_ir.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -p resolve | filecheck %s
+# RUN: veripy %s -t mlir | filecheck %s
 
 def f(a: int, b: int) -> int:
     if a >= b:

--- a/veripy/main.py
+++ b/veripy/main.py
@@ -1097,6 +1097,7 @@ class VeriPyMain(xDSLOptMain):
 
     def register_all_arguments(self, arg_parser: argparse.ArgumentParser):
         super().register_all_arguments(arg_parser)
+        arg_parser.set_defaults(passes="resolve", target="dfy")
         arg_parser.add_argument("--verify", default=False, action="store_true", help="Compile to Dafny and verify via Docker")
 
     def apply_passes(self, prog: ModuleOp) -> bool:


### PR DESCRIPTION
## Summary
- Set default passes to `resolve` and default target to `dfy` so `veripy input.py` emits Dafny with zero flags
- Power-user flags (`-p`, `-t`) still work for raw IR access

## Test plan
- [x] 30 pytest + 10 filecheck tests pass
- [x] `veripy example/example.py` outputs Dafny directly