### PR TITLE
Update stale example/example.py references

### DIFF
--- a/README
+++ b/README
@@ -20,8 +20,8 @@ Example
             return x
         return -x
 
-    $ veripy example/example.py
-    $ veripy example/example.py --verify
+    $ veripy example/abs.py
+    $ veripy example/abs.py --verify
 
 
 Pipeline

--- a/example/abs.py
+++ b/example/abs.py
@@ -1,4 +1,4 @@
-# uv run veripy example/example.py -p resolve -t dfy | docker run --rm -i xtrm0/dafny:4.9.1 sh -c 'cat > /tmp/out.dfy && dafny verify /tmp/out.dfy'
+# uv run veripy example/abs.py -p resolve -t dfy | docker run --rm -i xtrm0/dafny:4.9.1 sh -c 'cat > /tmp/out.dfy && dafny verify /tmp/out.dfy'
 
 def abs(x: int) -> int:
     #@ ensures result >= 0


### PR DESCRIPTION
## Summary
- Update README and example/abs.py to reference `example/abs.py` instead of the old `example/example.py` path (renamed in #36)

## Test plan
- [ ] Verify `example/abs.py` comment matches the actual file path
- [ ] Verify README examples use the correct path