### PR TITLE
Use uv run in README, pipe dfy to docker stdin

### DIFF
--- a/README
+++ b/README
@@ -20,8 +20,8 @@ Example
             return x
         return -x
 
-    $ veripy example/abs.py
-    $ veripy example/abs.py --verify
+    $ uv run veripy example/abs.py
+    $ uv run veripy example/abs.py --verify
 
 
 Pipeline

--- a/veripy/main.py
+++ b/veripy/main.py
@@ -5,7 +5,6 @@ import sys
 from collections.abc import Iterable, Sequence
 from dataclasses import dataclass
 from io import StringIO
-from pathlib import Path
 from re import compile as re_compile
 from typing import IO
 
@@ -692,9 +691,7 @@ class VeriPyMain(xDSLOptMain):
             if module is None:
                 continue
             dfy = print_dafny(module)
-            dfy_path = Path(self.args.input_file).with_suffix(".dfy")
-            dfy_path.write_text(dfy + "\n")
-            result = subprocess.run(["docker", "run", "--rm", "-v", f"{dfy_path.parent}:/work", "-w", "/work", "veripy-dafny", "dafny", "verify", dfy_path.name], capture_output=True, text=True)
+            result = subprocess.run(["docker", "run", "--rm", "-i", "xtrm0/dafny:4.9.1", "sh", "-c", "cat > /tmp/out.dfy && dafny verify /tmp/out.dfy"], input=dfy + "\n", capture_output=True, text=True)
             if result.stdout:
                 print(result.stdout)
             if result.stderr:


### PR DESCRIPTION
## Summary
- Prefix README example commands with `uv run`
- Replace volume-mount Docker invocation with stdin pipe using `xtrm0/dafny:4.9.1`, matching the pattern from the old `example/example.py`

## Test plan
- [x] All 15 LIT tests pass
- [ ] `uv run veripy example/abs.py --verify` runs with Docker