### PR TITLE
Add --platform linux/amd64 to docker run

### DIFF
--- a/example/abs.py
+++ b/example/abs.py
@@ -1,4 +1,4 @@
-# uv run veripy example/abs.py -p resolve -t dfy | docker run --rm -i xtrm0/dafny:4.9.1 sh -c 'cat > /tmp/out.dfy && dafny verify /tmp/out.dfy'
+# uv run veripy example/abs.py -p resolve -t dfy | docker run --rm -i --platform linux/amd64 xtrm0/dafny:4.9.1 sh -c 'cat > /tmp/out.dfy && dafny verify /tmp/out.dfy'
 
 def abs(x: int) -> int:
     #@ ensures result >= 0

--- a/veripy/main.py
+++ b/veripy/main.py
@@ -691,7 +691,7 @@ class VeriPyMain(xDSLOptMain):
             if module is None:
                 continue
             dfy = print_dafny(module)
-            result = subprocess.run(["docker", "run", "--rm", "-i", "xtrm0/dafny:4.9.1", "sh", "-c", "cat > /tmp/out.dfy && dafny verify /tmp/out.dfy"], input=dfy + "\n", capture_output=True, text=True)
+            result = subprocess.run(["docker", "run", "--rm", "-i", "--platform", "linux/amd64", "xtrm0/dafny:4.9.1", "sh", "-c", "cat > /tmp/out.dfy && dafny verify /tmp/out.dfy"], input=dfy + "\n", capture_output=True, text=True)
             if result.stdout:
                 print(result.stdout)
             if result.stderr:


### PR DESCRIPTION
## Summary
- Add `--platform linux/amd64` flag to the `docker run` command in `--verify` and in the `example/abs.py` comment

## Test plan
- [x] All 15 LIT tests pass
- [ ] `uv run veripy example/abs.py --verify` pulls and runs the correct image on Apple Silicon