### PR TITLE
Drop trailing commas, prefer single-line collections

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Strong success criteria let you loop independently. Weak criteria ("make it work
 
 These guidelines are working if: fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.
 
-# Syntax Guidelines
+# Code Guidelines
 
 - minimize indentation: guard first programming, early returns, happy path first
 - maximize for code locality: a little duplication is okay. inline small functions (<5 LoC)
@@ -70,3 +70,4 @@ These guidelines are working if: fewer unnecessary changes in diffs, fewer rewri
 
 - avoid OOP primitives like classes and inheritance where possible
 - use match statements over multiple `isinstance` branches
+- no trailing commas. no line length limit - prefer single-line imports, dicts and lists over multi-line with trailing commas

--- a/veripy/main.py
+++ b/veripy/main.py
@@ -17,26 +17,7 @@ from xdsl.utils.base_printer import BasePrinter
 from xdsl.utils.target import Target
 from xdsl.xdsl_opt_main import xDSLOptMain
 
-from veripy.ops_py import (
-    AssertOp,
-    AssignOp,
-    BinOp,
-    CallOp,
-    ConstantOp,
-    DecreasesOp,
-    EnsuresOp,
-    FuncOp,
-    IfOp,
-    InvariantOp,
-    NegOp,
-    ParamRefOp,
-    Py,
-    RequiresOp,
-    ReturnOp,
-    VarRefOp,
-    WhileOp,
-    YieldOp,
-)
+from veripy.ops_py import AssertOp, AssignOp, BinOp, CallOp, ConstantOp, DecreasesOp, EnsuresOp, FuncOp, IfOp, InvariantOp, NegOp, ParamRefOp, Py, RequiresOp, ReturnOp, VarRefOp, WhileOp, YieldOp
 
 #
 # ingestor
@@ -47,21 +28,7 @@ i1 = IntegerType(1)
 
 ANNOTATION_RE = re_compile(r"^\s*#@\s+(requires|ensures|invariant|decreases)\s+(.*?)\s*$")
 
-AST_OP: dict[type, tuple[str, IntegerType]] = {
-    ast.Eq: ("eq", i1),
-    ast.NotEq: ("ne", i1),
-    ast.Lt: ("lt", i1),
-    ast.LtE: ("le", i1),
-    ast.Gt: ("gt", i1),
-    ast.GtE: ("ge", i1),
-    ast.Add: ("add", i64),
-    ast.Sub: ("sub", i64),
-    ast.Mult: ("mul", i64),
-    ast.FloorDiv: ("floordiv", i64),
-    ast.Mod: ("mod", i64),
-    ast.And: ("and", i1),
-    ast.Or: ("or", i1),
-}
+AST_OP: dict[type, tuple[str, IntegerType]] = {ast.Eq: ("eq", i1), ast.NotEq: ("ne", i1), ast.Lt: ("lt", i1), ast.LtE: ("le", i1), ast.Gt: ("gt", i1), ast.GtE: ("ge", i1), ast.Add: ("add", i64), ast.Sub: ("sub", i64), ast.Mult: ("mul", i64), ast.FloorDiv: ("floordiv", i64), ast.Mod: ("mod", i64), ast.And: ("and", i1), ast.Or: ("or", i1)}
 
 
 def _resolve_type(ann: ast.expr | None) -> IntegerType:
@@ -323,21 +290,7 @@ class DfyExpr:
     prec: int
 
 
-BINOP_INFO: dict[str, tuple[str, int]] = {
-    "or": ("||", PREC_OR),
-    "and": ("&&", PREC_AND),
-    "eq": ("==", PREC_EQ),
-    "ne": ("!=", PREC_EQ),
-    "lt": ("<", PREC_CMP),
-    "le": ("<=", PREC_CMP),
-    "gt": (">", PREC_CMP),
-    "ge": (">=", PREC_CMP),
-    "add": ("+", PREC_ADD),
-    "sub": ("-", PREC_ADD),
-    "mul": ("*", PREC_MUL),
-    "floordiv": ("/", PREC_MUL),
-    "mod": ("%", PREC_MUL),
-}
+BINOP_INFO: dict[str, tuple[str, int]] = {"or": ("||", PREC_OR), "and": ("&&", PREC_AND), "eq": ("==", PREC_EQ), "ne": ("!=", PREC_EQ), "lt": ("<", PREC_CMP), "le": ("<=", PREC_CMP), "gt": (">", PREC_CMP), "ge": (">=", PREC_CMP), "add": ("+", PREC_ADD), "sub": ("-", PREC_ADD), "mul": ("*", PREC_MUL), "floordiv": ("/", PREC_MUL), "mod": ("%", PREC_MUL)}
 
 
 class DafnyPrinter(BasePrinter):

--- a/veripy/ops_py.py
+++ b/veripy/ops_py.py
@@ -1,23 +1,8 @@
 from collections.abc import Sequence
 
-from xdsl.dialects.builtin import (
-    ArrayAttr,
-    FunctionType,
-    IntegerAttr,
-    IntegerType,
-    StringAttr,
-)
+from xdsl.dialects.builtin import ArrayAttr, FunctionType, IntegerAttr, IntegerType, StringAttr
 from xdsl.ir import Dialect, Operation, Region, SSAValue
-from xdsl.irdl import (
-    IRDLOperation,
-    irdl_op_definition,
-    operand_def,
-    prop_def,
-    region_def,
-    result_def,
-    traits_def,
-    var_operand_def,
-)
+from xdsl.irdl import IRDLOperation, irdl_op_definition, operand_def, prop_def, region_def, result_def, traits_def, var_operand_def
 from xdsl.traits import IsolatedFromAbove, IsTerminator, Pure
 
 # xdsl's py dialect is dynamically typed (py.object) with only 3 ops.


### PR DESCRIPTION
## Summary
- Collapsed multi-line imports and dicts onto single lines, removing all trailing commas
- Added no-trailing-commas rule to CLAUDE.md (no line length limit)