### PR TITLE
Replace xDSLOptMain with plain click CLI

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ These guidelines are working if: fewer unnecessary changes in diffs, fewer rewri
 # Syntax Guidelines
 
 - minimize indentation: guard first programming, early returns, happy path first
-- maximize for code locality: a little duplication is okay. inline small functions (<5 LoC)
+- maximize for code locality: a little duplication is okay. inline small functions (<5 LoC). no module-level globals or top-level helpers unless reused in multiple places
 - maximize test coverage, without adding noise. prefer LIT tests over pytests
 
 - avoid OOP primitives like classes and inheritance where possible

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,10 @@
 name = "veripy"
 version = "0.0.1"
 requires-python = ">=3.12"
-dependencies = ["xdsl==0.63.0"]
+dependencies = [
+    "click>=8.3.3",
+    "xdsl==0.63.0",
+]
 
 [tool.uv]
 dev-dependencies = ["lit==18.1.8", "filecheck==1.0.3"]

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,27 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
+name = "click"
+version = "8.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bb/63/f9e1ea081ce35720d8b92acde70daaedace594dc93b693c869e0d5910718/click-8.3.3.tar.gz", hash = "sha256:398329ad4837b2ff7cbe1dd166a4c0f8900c3ca3a218de04466f38f6497f18a2", size = 328061, upload-time = "2026-04-22T15:11:27.506Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/44/c1221527f6a71a01ec6fbad7fa78f1d50dfa02217385cf0fa3eec7087d59/click-8.3.3-py3-none-any.whl", hash = "sha256:a2bf429bb3033c89fa4936ffb35d5cb471e3719e1f3c8a7c3fff0b8314305613", size = 110502, upload-time = "2026-04-22T15:11:25.044Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
 name = "filecheck"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -52,6 +73,7 @@ name = "veripy"
 version = "0.0.1"
 source = { editable = "." }
 dependencies = [
+    { name = "click" },
     { name = "xdsl" },
 ]
 
@@ -62,7 +84,10 @@ dev = [
 ]
 
 [package.metadata]
-requires-dist = [{ name = "xdsl", specifier = "==0.63.0" }]
+requires-dist = [
+    { name = "click", specifier = ">=8.3.3" },
+    { name = "xdsl", specifier = "==0.63.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [

--- a/veripy/main.py
+++ b/veripy/main.py
@@ -1,4 +1,3 @@
-import argparse
 import ast
 import subprocess
 import sys
@@ -8,35 +7,14 @@ from io import StringIO
 from re import compile as re_compile
 from typing import IO
 
-from xdsl.context import Context
 from xdsl.dialects.builtin import IntegerType, ModuleOp
 from xdsl.frontend.pyast.utils.exceptions import CodeGenerationException
 from xdsl.frontend.pyast.utils.op_inserter import OpInserter
 from xdsl.ir import Block, Operation, Region, SSAValue
+import click
 from xdsl.utils.base_printer import BasePrinter
-from xdsl.utils.target import Target
-from xdsl.xdsl_opt_main import xDSLOptMain
 
-from veripy.ops_py import (
-    AssertOp,
-    AssignOp,
-    BinOp,
-    CallOp,
-    ConstantOp,
-    DecreasesOp,
-    EnsuresOp,
-    FuncOp,
-    IfOp,
-    InvariantOp,
-    NegOp,
-    ParamRefOp,
-    Py,
-    RequiresOp,
-    ReturnOp,
-    VarRefOp,
-    WhileOp,
-    YieldOp,
-)
+from veripy.ops_py import AssertOp, AssignOp, BinOp, CallOp, ConstantOp, DecreasesOp, EnsuresOp, FuncOp, IfOp, InvariantOp, NegOp, ParamRefOp, RequiresOp, ReturnOp, VarRefOp, WhileOp, YieldOp
 
 #
 # ingestor
@@ -473,73 +451,32 @@ class DafnyPrinter(BasePrinter):
                 self._emit_stmt(op)
 
 
-def print_dafny(module: ModuleOp) -> str:
-    output = StringIO()
-    DafnyPrinter(output).print_module(module)
-    return output.getvalue()
-
-
-#
-# targets
-#
-
-
-@dataclass(frozen=True)
-class DafnyTarget(Target):
-    name = "dfy"
-
-    def emit(self, ctx: Context, module: ModuleOp, output: IO[str]) -> None:
-        DafnyPrinter(output).print_module(module)
-        output.write("\n")
-
-
 #
 # cli
 #
 
 
-class VeriPyMain(xDSLOptMain):
-    def register_all_dialects(self):
-        self.ctx.register_dialect("py", lambda: Py)
+@click.command()
+@click.argument("input", default="-")
+@click.option("--verify", is_flag=True, help="Compile to Dafny and verify via Docker")
+def cli(input, verify):
+    source = sys.stdin.read() if input == "-" else open(input).read()
+    module = ingest(source, input if input != "-" else None)
 
-    def register_all_frontends(self):
-        super().register_all_frontends()
+    buf = StringIO()
+    DafnyPrinter(buf).print_module(module)
+    dfy = buf.getvalue()
 
-        def parse_python(io: IO[str]):
-            return ingest(io.read(), self.get_input_name())
+    if not verify:
+        print(dfy)
+        return
 
-        self.available_frontends["py"] = parse_python
-
-    def register_all_targets(self):
-        super().register_all_targets()
-        self.available_targets["dfy"] = lambda: DafnyTarget
-
-    def register_all_arguments(self, arg_parser: argparse.ArgumentParser):
-        super().register_all_arguments(arg_parser)
-        arg_parser.set_defaults(target="dfy")
-        arg_parser.add_argument("--verify", default=False, action="store_true", help="Compile to Dafny and verify via Docker")
-
-    def apply_passes(self, prog: ModuleOp) -> bool:
-        self.pipeline.apply(self.ctx, prog)
-        return True
-
-    def run(self):
-        if not self.args.verify:
-            super().run()
-            return
-        chunks, ext = self.prepare_input()
-        for chunk, offset in chunks:
-            module = self.parse_chunk(chunk, ext, offset)
-            if module is None:
-                continue
-            dfy = print_dafny(module)
-            result = subprocess.run(["docker", "run", "--rm", "-i", "--platform", "linux/amd64", "xtrm0/dafny:4.9.1", "sh", "-c", "cat > /tmp/out.dfy && dafny verify /tmp/out.dfy"], input=dfy + "\n", capture_output=True, text=True)
-            if result.stdout:
-                print(result.stdout)
-            if result.stderr:
-                print(result.stderr, file=sys.stderr)
-            sys.exit(result.returncode)
-
-
-def cli():
-    VeriPyMain(description="VeriPy: Python to Dafny verification compiler").run()
+    result = subprocess.run(
+        ["docker", "run", "--rm", "-i", "--platform", "linux/amd64", "xtrm0/dafny:4.9.1", "sh", "-c", "cat > /tmp/out.dfy && dafny verify /tmp/out.dfy"],
+        input=dfy + "\n", capture_output=True, text=True
+    )
+    if result.stdout:
+        print(result.stdout)
+    if result.stderr:
+        print(result.stderr, file=sys.stderr)
+    sys.exit(result.returncode)


### PR DESCRIPTION
## Summary
- Drop `VeriPyMain` class hierarchy, `DafnyTarget`, `print_dafny`, and the xDSL CLI framework
- Replace with a single `@click.command()` decorated `cli()` function
- Inline all helpers and flatten multi-line import block
- Update CLAUDE.md syntax guidelines (code locality, no trailing commas, no line length limit)

## Test plan
- [x] `uv run veripy example/abs.py` produces identical Dafny output
- [x] `cat example/abs.py | uv run veripy` (stdin) works
- [x] `uv run veripy --help` shows usage