### PR TITLE
Inline module-level lookup tables into call sites

### DIFF
--- a/veripy/main.py
+++ b/veripy/main.py
@@ -20,29 +20,22 @@ from veripy.ops_py import AssertOp, AssignOp, BinOp, CallOp, ConstantOp, Decreas
 # ingestor
 #
 
-i64 = IntegerType(64)
-i1 = IntegerType(1)
-
-ANNOTATION_RE = re_compile(r"^\s*#@\s+(requires|ensures|invariant|decreases)\s+(.*?)\s*$")
-
-AST_OP: dict[type, tuple[str, IntegerType]] = {ast.Eq: ("eq", i1), ast.NotEq: ("ne", i1), ast.Lt: ("lt", i1), ast.LtE: ("le", i1), ast.Gt: ("gt", i1), ast.GtE: ("ge", i1), ast.Add: ("add", i64), ast.Sub: ("sub", i64), ast.Mult: ("mul", i64), ast.FloorDiv: ("floordiv", i64), ast.Mod: ("mod", i64), ast.And: ("and", i1), ast.Or: ("or", i1)}
-
-
 def _resolve_type(ann: ast.expr | None) -> IntegerType:
     match ann:
         case ast.Name(id="bool"):
-            return i1
+            return IntegerType(1)
         case _:
-            return i64
+            return IntegerType(64)
 
 
 def _extract_annotations(source: str, func_node: ast.FunctionDef) -> tuple[list[str], list[str]]:
+    annotation_re = re_compile(r"^\s*#@\s+(requires|ensures|invariant|decreases)\s+(.*?)\s*$")
     lines = source.splitlines()
     requires: list[str] = []
     ensures: list[str] = []
     for lineno in range(func_node.lineno, func_node.end_lineno or func_node.lineno + 1):
         line = lines[lineno - 1] if lineno <= len(lines) else ""
-        m = ANNOTATION_RE.match(line)
+        m = annotation_re.match(line)
         if not m:
             continue
         keyword, expr = m.group(1), m.group(2)
@@ -54,12 +47,13 @@ def _extract_annotations(source: str, func_node: ast.FunctionDef) -> tuple[list[
 
 
 def _extract_loop_annotations(source: str, node: ast.While) -> tuple[list[str], list[str]]:
+    annotation_re = re_compile(r"^\s*#@\s+(requires|ensures|invariant|decreases)\s+(.*?)\s*$")
     lines = source.splitlines()
     invariants: list[str] = []
     decreases_list: list[str] = []
     for lineno in range(node.lineno, node.end_lineno or node.lineno + 1):
         line = lines[lineno - 1] if lineno <= len(lines) else ""
-        m = ANNOTATION_RE.match(line)
+        m = annotation_re.match(line)
         if not m:
             continue
         keyword, expr = m.group(1), m.group(2)
@@ -131,48 +125,51 @@ class PyASTVisitor(ast.NodeVisitor):
     def visit_Constant(self, node: ast.Constant) -> None:
         match node.value:
             case bool() as v:
-                self.inserter.insert_op(ConstantOp(1 if v else 0, i1))
+                self.inserter.insert_op(ConstantOp(1 if v else 0, IntegerType(1)))
             case int() as v:
-                self.inserter.insert_op(ConstantOp(v, i64))
+                self.inserter.insert_op(ConstantOp(v, IntegerType(64)))
             case _:
                 raise self._err(node, f"unsupported constant: {node.value!r}")
 
     def visit_Name(self, node: ast.Name) -> None:
         if node.id in self.locals_:
-            self.inserter.insert_op(VarRefOp(node.id, self.scope.get(node.id, i64)))
+            self.inserter.insert_op(VarRefOp(node.id, self.scope.get(node.id, IntegerType(64))))
         else:
-            self.inserter.insert_op(ParamRefOp(node.id, self.scope.get(node.id, i64)))
+            self.inserter.insert_op(ParamRefOp(node.id, self.scope.get(node.id, IntegerType(64))))
 
     def visit_UnaryOp(self, node: ast.UnaryOp) -> None:
         if not isinstance(node.op, ast.USub):
             raise self._err(node, f"unsupported unary op: {type(node.op).__name__}")
         self.visit(node.operand)
-        self.inserter.insert_op(NegOp(self.inserter.get_operand(), i64))
+        self.inserter.insert_op(NegOp(self.inserter.get_operand(), IntegerType(64)))
 
     def visit_BinOp(self, node: ast.BinOp) -> None:
+        ast_op = {ast.Add: ("add", IntegerType(64)), ast.Sub: ("sub", IntegerType(64)), ast.Mult: ("mul", IntegerType(64)), ast.FloorDiv: ("floordiv", IntegerType(64)), ast.Mod: ("mod", IntegerType(64))}
         self.visit(node.left)
         lhs = self.inserter.get_operand()
         self.visit(node.right)
         rhs = self.inserter.get_operand()
-        s, ty = AST_OP[type(node.op)]
+        s, ty = ast_op[type(node.op)]
         self.inserter.insert_op(BinOp(s, lhs, rhs, ty))
 
     def visit_Compare(self, node: ast.Compare) -> None:
+        ast_op = {ast.Eq: ("eq", IntegerType(1)), ast.NotEq: ("ne", IntegerType(1)), ast.Lt: ("lt", IntegerType(1)), ast.LtE: ("le", IntegerType(1)), ast.Gt: ("gt", IntegerType(1)), ast.GtE: ("ge", IntegerType(1))}
         if len(node.ops) != 1 or len(node.comparators) != 1:
             raise self._err(node, "only single comparisons supported")
         self.visit(node.left)
         lhs = self.inserter.get_operand()
         self.visit(node.comparators[0])
         rhs = self.inserter.get_operand()
-        s, ty = AST_OP[type(node.ops[0])]
+        s, ty = ast_op[type(node.ops[0])]
         self.inserter.insert_op(BinOp(s, lhs, rhs, ty))
 
     def visit_BoolOp(self, node: ast.BoolOp) -> None:
+        ast_op = {ast.And: ("and", IntegerType(1)), ast.Or: ("or", IntegerType(1))}
         self.visit(node.values[0])
         lhs = self.inserter.get_operand()
         self.visit(node.values[1])
         rhs = self.inserter.get_operand()
-        s, ty = AST_OP[type(node.op)]
+        s, ty = ast_op[type(node.op)]
         self.inserter.insert_op(BinOp(s, lhs, rhs, ty))
 
     def visit_Call(self, node: ast.Call) -> None:
@@ -182,7 +179,7 @@ class PyASTVisitor(ast.NodeVisitor):
         for a in node.args:
             self.visit(a)
             args.append(self.inserter.get_operand())
-        self.inserter.insert_op(CallOp(node.func.id, args, i64))
+        self.inserter.insert_op(CallOp(node.func.id, args, IntegerType(64)))
 
     def visit_Assign(self, node: ast.Assign) -> None:
         if len(node.targets) != 1 or not isinstance(node.targets[0], ast.Name):
@@ -192,7 +189,7 @@ class PyASTVisitor(ast.NodeVisitor):
         val = self.inserter.get_operand()
         is_decl = name not in self.locals_ and name not in self.scope
         self.inserter.insert_op(AssignOp(name, val, is_decl))
-        self.scope[name] = i64
+        self.scope[name] = IntegerType(64)
         self.locals_.add(name)
 
     def visit_Return(self, node: ast.Return) -> None:
@@ -267,23 +264,10 @@ def ingest(source: str, file: str | None = None) -> ModuleOp:
 # dafny lowering
 #
 
-PREC_OR = 1
-PREC_AND = 2
-PREC_EQ = 3
-PREC_CMP = 4
-PREC_ADD = 5
-PREC_MUL = 6
-PREC_UNARY = 7
-PREC_ATOM = 8
-
-
 @dataclass
 class DfyExpr:
     text: str
     prec: int
-
-
-BINOP_INFO: dict[str, tuple[str, int]] = {"or": ("||", PREC_OR), "and": ("&&", PREC_AND), "eq": ("==", PREC_EQ), "ne": ("!=", PREC_EQ), "lt": ("<", PREC_CMP), "le": ("<=", PREC_CMP), "gt": (">", PREC_CMP), "ge": (">=", PREC_CMP), "add": ("+", PREC_ADD), "sub": ("-", PREC_ADD), "mul": ("*", PREC_MUL), "floordiv": ("/", PREC_MUL), "mod": ("%", PREC_MUL)}
 
 
 class DafnyPrinter(BasePrinter):
@@ -328,10 +312,10 @@ class DafnyPrinter(BasePrinter):
         self.print_string("\n}")
 
     def _eval_expr_op(self, op: Operation) -> None:
+        binop_info = {"or": ("||", 1), "and": ("&&", 2), "eq": ("==", 3), "ne": ("!=", 3), "lt": ("<", 4), "le": ("<=", 4), "gt": (">", 4), "ge": (">=", 4), "add": ("+", 5), "sub": ("-", 5), "mul": ("*", 6), "floordiv": ("/", 6), "mod": ("%", 6)}
         match op:
             case BinOp():
-                kind = op.op_kind.data
-                sym, prec = BINOP_INFO[kind]
+                sym, prec = binop_info[op.op_kind.data]
                 l, r = self.exprs[op.lhs], self.exprs[op.rhs]
                 lt = f"({l.text})" if l.prec < prec else l.text
                 rt = f"({r.text})" if r.prec <= prec else r.text
@@ -341,21 +325,21 @@ class DafnyPrinter(BasePrinter):
                     text = "true" if op.value.value.data else "false"
                 else:
                     text = str(op.value.value.data)
-                self.exprs[op.result] = DfyExpr(text, PREC_ATOM)
+                self.exprs[op.result] = DfyExpr(text, 8)
             case ParamRefOp():
                 name = op.param_name.data
                 if name == "result":
                     name = "r"
-                self.exprs[op.result] = DfyExpr(name, PREC_ATOM)
+                self.exprs[op.result] = DfyExpr(name, 8)
             case VarRefOp():
-                self.exprs[op.result] = DfyExpr(op.var_name.data, PREC_ATOM)
+                self.exprs[op.result] = DfyExpr(op.var_name.data, 8)
             case NegOp():
                 inner = self.exprs[op.operand]
-                text = f"-{inner.text}" if inner.prec >= PREC_UNARY else f"-({inner.text})"
-                self.exprs[op.result] = DfyExpr(text, PREC_UNARY)
+                text = f"-{inner.text}" if inner.prec >= 7 else f"-({inner.text})"
+                self.exprs[op.result] = DfyExpr(text, 7)
             case CallOp():
                 args = ", ".join(self.exprs[a].text for a in op.arguments)
-                self.exprs[op.result] = DfyExpr(f"{op.callee.data}({args})", PREC_ATOM)
+                self.exprs[op.result] = DfyExpr(f"{op.callee.data}({args})", 8)
 
     def _emit_stmt(self, op: Operation) -> None:
         match op:


### PR DESCRIPTION
## Summary
- Remove `i64`, `i1`, `ANNOTATION_RE`, `AST_OP`, `PREC_*`, and `BINOP_INFO` module-level globals
- Inline each as a local variable in the function/method that uses it
- Split `AST_OP` into purpose-specific dicts per visitor method (arithmetic, comparison, boolean)