### PR TITLE
Remove dead CLI flags from LIT test RUN lines

### DIFF
--- a/example/abs.py
+++ b/example/abs.py
@@ -1,4 +1,4 @@
-# uv run veripy example/abs.py -p resolve -t dfy | docker run --rm -i --platform linux/amd64 xtrm0/dafny:4.9.1 sh -c 'cat > /tmp/out.dfy && dafny verify /tmp/out.dfy'
+# uv run veripy example/abs.py | docker run --rm -i --platform linux/amd64 xtrm0/dafny:4.9.1 sh -c 'cat > /tmp/out.dfy && dafny verify /tmp/out.dfy'
 
 
 def abs(x: int) -> int:

--- a/tests/filecheck/abs.py
+++ b/tests/filecheck/abs.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 def abs(x: int) -> int:
     #@ ensures result >= 0
     #@ ensures result == x or result == -x

--- a/tests/filecheck/arithmetic.py
+++ b/tests/filecheck/arithmetic.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def add(a: int, b: int) -> int:
     return a + b

--- a/tests/filecheck/assert.py
+++ b/tests/filecheck/assert.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def f(x: int) -> int:
     assert x >= 0

--- a/tests/filecheck/assign.py
+++ b/tests/filecheck/assign.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def simple(x: int) -> int:
     y = x + 1

--- a/tests/filecheck/bool.py
+++ b/tests/filecheck/bool.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def identity(x: bool) -> bool:
     return x

--- a/tests/filecheck/boolean.py
+++ b/tests/filecheck/boolean.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def both(a: int, b: int) -> int:
     if a >= 0 and b >= 0:

--- a/tests/filecheck/call.py
+++ b/tests/filecheck/call.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def one_arg(x: int) -> int:
     return g(x)

--- a/tests/filecheck/comparisons.py
+++ b/tests/filecheck/comparisons.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def eq(a: int, b: int) -> int:
     if a == b:

--- a/tests/filecheck/constant.py
+++ b/tests/filecheck/constant.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 def forty_two() -> int:
     return 42
 # CHECK: method forty_two() returns (r: int)

--- a/tests/filecheck/if_else.py
+++ b/tests/filecheck/if_else.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 def max(a: int, b: int) -> int:
     #@ ensures result >= a
     #@ ensures result >= b

--- a/tests/filecheck/multi_func.py
+++ b/tests/filecheck/multi_func.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def f() -> int:
     return 1

--- a/tests/filecheck/requires.py
+++ b/tests/filecheck/requires.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def add_nonneg(a: int, b: int) -> int:
     #@ requires a >= 0

--- a/tests/filecheck/while.py
+++ b/tests/filecheck/while.py
@@ -1,4 +1,4 @@
-# RUN: veripy %s -t dfy | filecheck %s
+# RUN: veripy %s | filecheck %s
 
 def simple(x: int) -> int:
     while x > 0:


### PR DESCRIPTION
## Summary
- Remove `-t dfy` flag from all 13 filecheck test RUN lines — the CLI has no `-t`/`--target` option
- Remove `-p resolve` flag from the example RUN line — the CLI has no `-p`/`--pass` option either

## Test plan
- [x] `uv run lit tests/filecheck -v` — all 13 filecheck tests pass (2 pre-existing `py_ir` failures unrelated)